### PR TITLE
Simplify how we use hydra config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ pf/**
 
 
 .vscode/launch.json
+
+# Hydra
+*.log

--- a/INSTALL
+++ b/INSTALL
@@ -4,12 +4,9 @@ In addition the pip requirements file needs to be properly maintained.
 
 # Installation
 
-We recommend the usage of mamba for setting up Python environment:
+https://github.com/conda-forge/miniforge#mambaforge
 
-```bash
-## Install mamba
-conda install mamba -n base -c conda-forge
-conda update mamba -c conda-forge
+```Bash
 mamba init
 
 ## Create new environment

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 CMake (pip install cmake=3.20.2)
 zlib (apt install zlib1g zlib1g-dev)
+build-essentials (apt install build-essentials)
 
 ## Random reference genome step
 

--- a/config/asm/la_jolla.yaml
+++ b/config/asm/la_jolla.yaml
@@ -10,15 +10,15 @@ params:
     # K: 2001 # not supported for jumboDBG
   append: "--compress"
 
-keep:
-  [
-    "graph.gfa",
-    "mult.info",
-    "ref.info",
-    "disjointigs.fasta",
-    "graph.dot",
-    "alignments.txt",
-  ]
+keep: null
+#  [
+#    "graph.gfa",
+#    "mult.info",
+#    "ref.info",
+#    "disjointigs.fasta",
+#    "graph.dot",
+#    "alignments.txt",
+#  ]
 exec: jumboDBG # name of the executable to use (jumboDBG or lja)
 full_asm: full_asm # execute LJA so that we have all the files for comparison and save in this dir
 

--- a/config/assembly.yaml
+++ b/config/assembly.yaml
@@ -7,12 +7,12 @@
 defaults:
   - hydra: hydra
   - paths: paths
-  - species_name@_global_: random_species
+  - species_name: null
   - asm: la_jolla
   - _self_
 
 date_mm_dd: ${now:%m_%d}
-experiment: ${species_name}
+experiment: ${species_name.name}
 suffix:
   reads:
     - .fastq

--- a/config/graph.yaml
+++ b/config/graph.yaml
@@ -3,12 +3,12 @@
 defaults:
   - hydra: hydra
   - paths: paths
-  - species_name@_global_: random_species
+  - species_name: null
   - graph: db_graph
   - _self_
 
 date_mm_dd: ${now:%m_%d}
-experiment: ${species_name}
+experiment: ${species_name.name}
 graph:
   set:
     name: train

--- a/config/paths/paths.yaml
+++ b/config/paths/paths.yaml
@@ -8,16 +8,15 @@ root_dir: ${oc.env:PROJECT_ROOT}
 vendor_dir: ${paths.root_dir}/vendor
 
 # path to data directory
-data_dir: ${paths.root_dir}/data/
+data_dir: /data/
 # path to genome references
-ref_dir: ${paths.root_dir}/data/references/
+ref_dir: ${paths.data_dir}/references/
 # path to sequencing reads
-# TODO: rename this to `reads_dir`
-reads_dir: ${paths.root_dir}/data/reads
+reads_dir: ${paths.data_dir}/reads
 # path to results of genome assembly
-assemblies_dir: ${paths.root_dir}/data/assemblies
+assemblies_dir: ${paths.data_dir}/assemblies
 # path to ML datasets shared with train/inference pipeline
-datasets_dir: ${paths.root_dir}/data/datasets #/home/data/datasets
+datasets_dir: ${paths.data_dir}/datasets
 
 # path for storing the outputs of the specific run
 # see hydra config for the exact format used

--- a/config/reads/pbsim3_pf.yaml
+++ b/config/reads/pbsim3_pf.yaml
@@ -4,7 +4,7 @@ threads: 15 # set if you want to override (default is os.cpu_count() - 1)
 
 params:
   long: # command line params starting with --
-    depth: 30
+    depth: 25
     strategy: wgs
     method: sample
     sample-profile-id: pf1 # make sure that the id matches one in the profile path

--- a/config/reference.yaml
+++ b/config/reference.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
   - hydra: hydra
   - paths: paths
-  - species_name@_global_: random_species
-  - reference: ${species_name@_global_}
+  - species_name: null
+  - reference: null 
 
 seed: 42

--- a/config/reference/random_species.yaml
+++ b/config/reference/random_species.yaml
@@ -2,7 +2,7 @@
 # Generated data is saved to $PROJECT_ROOT/data/refrence/${species_name}.
 # Each chromosome is saved in separate file, eg. chr1.fasta, chr2.fasta...
 chromosomes:
-  chr1: 100000
+  chr1: 30000
 
 gc_content: 0.44 # Percentage of G and C bases. Specify as float in range [0., 1.).
 real_data: # set to True if this is config describing non-simulated dataset

--- a/config/sequencing.yaml
+++ b/config/sequencing.yaml
@@ -2,7 +2,7 @@
 defaults:
   - hydra: hydra
   - paths: paths
-  - species_name@_global_: random_species
+  - species_name: null
   - reads: pbsim3_pf
   - _self_
 

--- a/config/species_name/chr_10_homunculus.yaml
+++ b/config/species_name/chr_10_homunculus.yaml
@@ -1,1 +1,0 @@
-species_name: chr_10_homunculus

--- a/config/species_name/homo_sapiens_chr_01.yaml
+++ b/config/species_name/homo_sapiens_chr_01.yaml
@@ -1,0 +1,1 @@
+name: homo_sapiens_chr_01

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,6 +20,8 @@ dependencies:
 
   # ML
   - pyg::pyg
+  - pyg::pytorch-sparse
+  - pyg::pytorch-cluster
   - pytorch-cuda=11.8
   - conda-forge::lightning
   - pytorch::torchaudio
@@ -27,6 +29,10 @@ dependencies:
   - ogb
   - conda-forge::torchmetrics
   - wandb
+
+  # Math
+  - numpy
+  - scipy
 
   # Bio
   - biopython
@@ -52,3 +58,5 @@ dependencies:
 
   - pip:
       - hydra-colorlog
+      - distinctipy
+      - jupyterlab

--- a/src/asm/assembler.py
+++ b/src/asm/assembler.py
@@ -46,8 +46,8 @@ def assembly_experiment_path(cfg: DictConfig) -> Path:
 
 def run(cfg: DictConfig, **kwargs):
     exec_args = {
-        "reads_path": Path(cfg.paths.reads_dir) / cfg.species_name,
-        "ref_path": Path(cfg.paths.ref_dir) / cfg.species_name / "chromosomes",
+        "reads_path": Path(cfg.paths.reads_dir) / cfg.species_name["name"],
+        "ref_path": Path(cfg.paths.ref_dir) / cfg.species_name["name"] / "chromosomes",
         "out_path": assembly_experiment_path(cfg),
         "suffix": OmegaConf.to_container(cfg.suffix),
     }

--- a/src/graph/construct_graph.py
+++ b/src/graph/construct_graph.py
@@ -110,7 +110,7 @@ def construct_graphs(gfa_path: Path, k: int) -> Tuple[Dict[str, DbGraphType], Di
     segments, links = parse_gfa(path=gfa_path, k=k)
     graphs = {}
     labels = {}
-    segments_ = deepcopy(segments)
-    graphs["digraph"], labels["digraph"] = construct_nx_digraph(segments_, links, k=k)
+    # segments_ = deepcopy(segments)
+    # graphs["digraph"], labels["digraph"] = construct_nx_digraph(segments_, links, k=k)
     graphs["multidigraph"], labels["multidigraph"] = construct_nx_multigraph(segments, k=k)
     return graphs, labels

--- a/src/graph/db_graph.py
+++ b/src/graph/db_graph.py
@@ -106,8 +106,8 @@ def process_graph_mp(
 def run(cfg: DictConfig, **kwargs):
 
     exec_args = {
-        "assemblies_path": cfg.paths.assemblies_dir / cfg.species_name,
-        "out_path": cfg.paths.datasets_dir / f"{cfg.species_name}_{cfg.date_mm_dd}" / cfg.graph.set.name,
+        "assemblies_path": cfg.paths.assemblies_dir / cfg.species_name.name,
+        "out_path": cfg.paths.datasets_dir / f"{cfg.species_name.name}_{cfg.date_mm_dd}" / cfg.graph.set.name,
     }
 
     exec_args.update(kwargs)
@@ -142,8 +142,11 @@ def run(cfg: DictConfig, **kwargs):
         mp_data.append([idx, graph_dir, cfg, out_processed_paths, out_raw_paths, out_debug_paths])
 
     print(f"Processing {len(mp_data)} graphs with {threads} threads")
+    #if len(mp_data) == 1:
+    #    processed_results = [process_graph_mp(*mp_data[0])]
     with mp.Pool(threads) as pool:
         processed_results = pool.starmap(process_graph_mp, mp_data)
+    
 
     # Merge results
     processed_files = defaultdict(list)

--- a/src/reads/reads_simulator.py
+++ b/src/reads/reads_simulator.py
@@ -194,12 +194,12 @@ def simulator_factory(simulator: str, cfg: DictConfig) -> RSimulator:
 
 
 def run(cfg: DictConfig, **kwargs):
-    output_path = Path(cfg.paths.reads_dir) / cfg.species_name / cfg.date_mm_dd / f"S{cfg.seed}"
+    output_path = Path(cfg.paths.reads_dir) / cfg.species_name["name"] / cfg.date_mm_dd / f"S{cfg.seed}"
     exec_args = {
         # Top level output path
         "simulated_species_path": output_path,
         # Path to the reference genome directory (can contain one or multiple fasta files)
-        "ref_root": Path(cfg.paths.ref_dir) / cfg.species_name,
+        "ref_root": Path(cfg.paths.ref_dir) / cfg.species_name["name"],
         "experiment": cfg.experiment,
     }
     exec_args.update(kwargs)

--- a/src/reference/genome_generator.py
+++ b/src/reference/genome_generator.py
@@ -75,7 +75,7 @@ def save_genome_to_fasta(output_path: Path, genome: Dict[str, str], description:
 
 def species_reference_root(cfg: DictConfig) -> Path:
     references_dir = Path(cfg.paths.ref_dir)
-    species_name = str(cfg.species_name)
+    species_name = str(cfg.species_name["name"])
     return references_dir / species_name
 
 
@@ -87,16 +87,15 @@ def run(cfg):
     species_path = species_reference_root(cfg)
 
     if species_path.exists():
-        print(f"Reference genome for species `{cfg.species_name}` already exists at location: \n{species_path}")
+        print(f"Reference genome for species `{cfg.species_name['name']}` already exists at location: \n{species_path}")
         print("Skipping...")
         return False
 
     try:
-        print(cfg)
         species_path.mkdir(parents=True)
 
         species_info = {
-            "species_name": cfg.species_name,
+            "species_name": cfg.species_name["name"],
             "chromosomes": dict(cfg.reference.chromosomes),
             "gc_content": cfg.reference.gc_content,
             "seed": cfg.seed,


### PR DESCRIPTION
This allows us to run the entire pipeline without need to create those configs in reference folder, but just by
refering existing reference directory ("/data/references")
E.g.

"args": ["+species_name={name: random_species_100000}", "reference=random_species"]
"args": ["+species_name={name: random_species_100000}"]