### PR TITLE
Add tracking summary as metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,10 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [--fix]
+        args: [--fix, --line-length=120]
       # Run the formatter.
       - id: ruff-format
+        args: [--line-length=120]
 
   # python upgrading syntax to newer version
   - repo: https://github.com/asottile/pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
-      # - id: check-executables-have-shebangs
+      - id: check-executables-have-shebangs
       - id: check-vcs-permalinks
       - id: check-yaml
       - id: debug-statements
@@ -27,25 +27,22 @@ repos:
         exclude: "scripts/lja_eval.patch"
 
   # python code formatting
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.3.5
     hooks:
-      - id: black
-        args: [--line-length, "119"]
-
-  # python import sorting
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
 
   # python upgrading syntax to newer version
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
   # python docstring formatting
   - repo: https://github.com/myint/docformatter
@@ -92,6 +89,12 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
+
+  # shell scripts linter
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
 
   # md formatting
   - repo: https://github.com/executablebooks/mdformat

--- a/config/experiment/experiment.yaml
+++ b/config/experiment/experiment.yaml
@@ -1,7 +1,7 @@
 scenario:
   name: random_scenario #  can be with or without .json
 
-experiment_id: ${now:%Y%m%d_%H%M}
+experiment_id: ${now:%y%m%d_%H%M}
 max_workers: 1
 
 keep:

--- a/config/experiment/scenarios/chm13_chr11.json
+++ b/config/experiment/scenarios/chm13_chr11.json
@@ -17,5 +17,6 @@
       "species_name": "chm13.yaml"
     }
   ],
+  "schema": "0.0.1",
   "subset": "test"
 }

--- a/config/experiment/scenarios/random_scenario.json
+++ b/config/experiment/scenarios/random_scenario.json
@@ -17,5 +17,6 @@
       "species_name": "random_species.yaml"
     }
   ],
+  "schema": "0.0.1",
   "subset": "train"
 }

--- a/src/asm/la_jolla.py
+++ b/src/asm/la_jolla.py
@@ -120,7 +120,7 @@ class LaJolla(assembler.Assembler):
 
         for cmd in commands:
             logger.info(f"RUN::assembler::\n{cmd}")
-            subprocess.run(cmd, shell=True, cwd=output_path)
+            subprocess.run(cmd, shell=True, cwd=output_path, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
     @typechecked
     def pre_assembly_step(self, output_path: Path, *args, **kwargs):

--- a/src/experiment/dataset_summary.py
+++ b/src/experiment/dataset_summary.py
@@ -1,0 +1,56 @@
+from itertools import product
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import pandas as pd
+from omegaconf import DictConfig
+
+import experiment.experiment_utils as eu
+from experiment.scenario_schema import Scenario
+
+
+@dataclass
+class DatasetInfoEntry:
+    Subset: str
+    Id: int
+    Species: str
+    Chromosomes: list[str]
+    Seed: int
+    Probability: float
+    ProfileId: str | None
+    RunId: str
+    Version: str
+
+
+def create_entries_summary(cfg: DictConfig, scenario: Scenario) -> list:
+    # first constants
+    subset = scenario.subset
+    read_sampling = "simulate" if cfg.reads.name == "pbsim3" else "sample"
+    profile_id = cfg.reads.params.long["sample-profile-id"] if read_sampling == "simulate" else ""
+    run_id = cfg.experiment.experiment_id
+    version = scenario.schema
+
+    summary = []
+    id = 0
+    for item in scenario.items:
+        species = item.species_name
+        for sample in item.samples:
+            chromosomes = [chr.name for chr in sample.chromosomes]
+            probabilities = eu.get_sequencing_probabilities(sample.probability)
+            sequencing_seeds = eu.get_sequencing_seeds(scenario.subset, sample.count, sample.init_seed)
+            for probability, seed in product(probabilities, sequencing_seeds):
+                entry = DatasetInfoEntry(
+                    subset, id, species, chromosomes, seed, probability, profile_id, run_id, version
+                )
+                summary.append(entry)
+                id += 1
+
+    return summary
+
+
+def entries_summary_to_csv(entries: list, output_path: Path, filename: str = "summary.csv"):
+    if len(entries) == 0:
+        return
+    data = [asdict(entry) for entry in entries]
+    df = pd.DataFrame(data)
+    df.to_csv(output_path / filename, index=False, float_format="%.3f")

--- a/src/experiment/scenario_schema.py
+++ b/src/experiment/scenario_schema.py
@@ -1,6 +1,7 @@
 """
 Generated with dataclass-wizard -> cat scenario.json | wiz gs - scenario_schema
 """
+
 from dataclasses import dataclass
 
 from dataclass_wizard import JSONWizard
@@ -12,6 +13,7 @@ import experiment.experiment_utils as eu
 class Scenario(JSONWizard):
     """Data dataclass."""
 
+    schema: str
     dataset: str
     subset: str
     items: list["Item"]

--- a/test/config/experiment/scenarios/test_scenario_sampler.json
+++ b/test/config/experiment/scenarios/test_scenario_sampler.json
@@ -27,5 +27,6 @@
       "species_name": "test_species.yaml"
     }
   ],
+  "schema": "0.0.1",
   "subset": "train"
 }

--- a/test/config/experiment/scenarios/test_scenario_sim.json
+++ b/test/config/experiment/scenarios/test_scenario_sim.json
@@ -30,5 +30,6 @@
       "species_name": "test_species.yaml"
     }
   ],
+  "schema": "0.0.1",
   "subset": "test"
 }

--- a/test/config/experiment/test_experiment_sim.yaml
+++ b/test/config/experiment/test_experiment_sim.yaml
@@ -1,7 +1,7 @@
 scenario:
   name: test_scenario_sim.json # can be with or without .json
 
-experiment_id: ${now:%Y%m%d_%H%M}
+experiment_id: ${now:%y%m%d_%H%M}
 max_workers: 1
 
 keep:

--- a/test/unit/experiment/test_schedule.py
+++ b/test/unit/experiment/test_schedule.py
@@ -27,9 +27,7 @@ def test_create_sequencing_jobs(tmpdir, test_scenario_sim, test_data_reference):
     assert job["output_path"].relative_to(staging_root) == Path("2/reads")
 
 
-def test_schedule_run_sim_creates_expected_outputs(
-    test_cfg_root, test_experiment_sim_cfg, test_scenarios_root, tmpdir
-):
+def test_schedule_run_sim_creates_expected_outputs(test_cfg_root, test_experiment_sim_cfg, test_scenarios_root, tmpdir):
     test_experiment_sim_cfg.paths.exp_dir = str(tmpdir)
     test_experiment_sim_cfg.paths.datasets_dir = str(tmpdir)
     with mock.patch("experiment.experiment_utils.get_scenario_root", return_value=test_scenarios_root), mock.patch(
@@ -41,6 +39,8 @@ def test_schedule_run_sim_creates_expected_outputs(
     assert len(list((Path(tmpdir) / "unittest_dataset" / "test").glob("**/*.pt"))) == 3
     eval_path = Path(tmpdir) / "unittest_dataset" / "eval"
     assert eval_path.exists()
+    metadata_path = Path(tmpdir) / "unittest_dataset" / "metadata"
+    assert metadata_path.exists()
     for sample_idx in ["0", "1", "2"]:
         # do hard-coded checking, actually should be cross-checked with experiment.keep option
         assert eval_path / sample_idx / "reads" / "sim_0001.fastq"
@@ -60,5 +60,6 @@ def test_schedule_run_sample_creates_expected_outputs(
         run(test_experiment_sampler_cfg)
 
     assert (Path(tmpdir) / "unittest_dataset").exists()
+    assert (Path(tmpdir) / "unittest_dataset" / "metadata").exists()
 
     assert len(list((Path(tmpdir) / "unittest_dataset" / "train" / "raw").iterdir())) == 3


### PR DESCRIPTION
Save run metadata in dataset summary file. This will be used
to prevent duplicates in the data in the future runs. Also
it should be included in W&B dataset metadata.

Smaller improvements:
- pre-commit uses ruff
- supress LJA output as the program creates log anyway

Closes #162 