### PR TITLE
Keep graph from jumbo for test samples

### DIFF
--- a/config/experiment/experiment.yaml
+++ b/config/experiment/experiment.yaml
@@ -8,5 +8,5 @@ keep:
   artifacts_path: "eval"
   # either matches as fnmatch.fnmatch(path, pattern) or pathlib.Path(path).name == pattern
   reads: ["*.fastq"]
-  assemblies: ["mult.info", "full_asm.json"]
+  assemblies: ["mult.info", "full_asm.json", "graph.gfa"]
   graph: ["*.idmap", "*.hashmap"]

--- a/test/config/experiment/test_experiment_sim.yaml
+++ b/test/config/experiment/test_experiment_sim.yaml
@@ -8,5 +8,5 @@ keep:
   artifacts_path: "eval"
   # either matches as fnmatch.fnmatch(path, pattern) or pathlib.Path(path).name == pattern
   reads: ["*.fastq"]
-  assemblies: ["mult.info", "full_asm.json"]
+  assemblies: ["mult.info", "full_asm.json", "graph.gfa"]
   graph: ["*.idmap", "*.hashmap"]

--- a/test/unit/experiment/test_schedule.py
+++ b/test/unit/experiment/test_schedule.py
@@ -45,6 +45,7 @@ def test_schedule_run_sim_creates_expected_outputs(test_cfg_root, test_experimen
         # do hard-coded checking, actually should be cross-checked with experiment.keep option
         assert eval_path / sample_idx / "reads" / "sim_0001.fastq"
         assert eval_path / sample_idx / "assemblies" / "mult.info"
+        assert eval_path / sample_idx / "assemblies" / "graph.gfa"
         assert eval_path / sample_idx / "graph" / "debug" / "0.idmap"
         assert eval_path / sample_idx / "graph" / "debug" / "0.hashmap"
 


### PR DESCRIPTION
Closes #185

In order to easier debug edge cases it is better to keep graph.gfa
from jumbo run
