### PR TITLE
Improves error handling so that some errors are recoverable and jobs can now timeout

### DIFF
--- a/config/experiment/experiment.yaml
+++ b/config/experiment/experiment.yaml
@@ -3,6 +3,7 @@ scenario:
 
 experiment_id: ${now:%y%m%d_%H%M}
 max_workers: 1
+timeout_in_minutes: 120
 
 # here we define the available profiles for simulation
 # this way we can verify that the scenario uses right setting

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,14 +14,14 @@ dependencies:
   - cmake
 
   # ML
-  - pytorch::pytorch-cuda
+  - pytorch::pytorch
   - pytorch::torchaudio
   - pytorch::torchvision
   - pyg::pyg
   - wandb
 
   # Stats
-  - numpy
+  - numpy=1.26.4
   - scipy
   - pandas
 

--- a/src/experiment/dataset_summary.py
+++ b/src/experiment/dataset_summary.py
@@ -25,7 +25,7 @@ class DatasetInfoEntry:
     Schema: str
 
 
-def create_entries_summary(cfg: DictConfig, scenario: Scenario, collected_samples: dict) -> list:
+def create_entries_summary(cfg: DictConfig, scenario: Scenario, collected_samples: list) -> list:
     # first constants
     subset = scenario.subset
     read_sampling = "simulate" if cfg.reads.name == "pbsim3" else "sample"
@@ -43,25 +43,28 @@ def create_entries_summary(cfg: DictConfig, scenario: Scenario, collected_sample
             probabilities = eu.get_sequencing_probabilities(sample.probability)
             sequencing_seeds = eu.get_sequencing_seeds(scenario.subset, sample.count, sample.init_seed)
             for probability, seed in product(probabilities, sequencing_seeds):
-                features_key = list(collected_samples)[id]
-                features = collected_samples[features_key]
-                num_nodes, num_edges = features["num_nodes"], features["num_edges"]
-                entry = DatasetInfoEntry(
-                    subset,
-                    id,
-                    species,
-                    chromosomes,
-                    num_nodes,
-                    num_edges,
-                    seed,
-                    probability,
-                    profile_id,
-                    depth,
-                    run_id,
-                    schema,
-                )
-                summary.append(entry)
-                id += 1
+                if id < len(collected_samples):
+                    entry = collected_samples[id]
+                    id += 1
+                    if entry is None:
+                        continue
+                    sample_id, features = entry
+                    num_nodes, num_edges = features["num_nodes"], features["num_edges"]
+                    entry = DatasetInfoEntry(
+                        subset,
+                        sample_id,
+                        species,
+                        chromosomes,
+                        num_nodes,
+                        num_edges,
+                        seed,
+                        probability,
+                        profile_id,
+                        depth,
+                        run_id,
+                        schema,
+                    )
+                    summary.append(entry)
 
     return summary
 

--- a/test/config/experiment/test_experiment_sim.yaml
+++ b/test/config/experiment/test_experiment_sim.yaml
@@ -8,6 +8,7 @@ profiles:
 
 experiment_id: ${now:%y%m%d_%H%M}
 max_workers: 1
+timeout_in_minutes: 10
 
 keep:
   artifacts_path: "eval"

--- a/test/unit/experiment/test_schedule.py
+++ b/test/unit/experiment/test_schedule.py
@@ -27,6 +27,18 @@ def test_create_sequencing_jobs(tmpdir, test_scenario_sim, test_data_reference):
     assert job["output_path"].relative_to(staging_root) == Path("2/reads")
 
 
+def test_schedule_run_sim_timeouts(test_cfg_root, test_experiment_sim_cfg, test_scenarios_root, tmpdir):
+    test_experiment_sim_cfg.paths.exp_dir = str(tmpdir)
+    test_experiment_sim_cfg.paths.datasets_dir = str(tmpdir)
+    # gives jobs just 1 second of time to complete so they all fail
+    test_experiment_sim_cfg.experiment.timeout_in_minutes = 0
+    with mock.patch("experiment.experiment_utils.get_scenario_root", return_value=test_scenarios_root), mock.patch(
+        "utils.path_helpers.get_config_root", return_value=test_cfg_root
+    ):
+        jobs_completed = run(test_experiment_sim_cfg)
+        assert jobs_completed == 0
+
+
 def test_schedule_run_sim_creates_expected_outputs(test_cfg_root, test_experiment_sim_cfg, test_scenarios_root, tmpdir):
     test_experiment_sim_cfg.paths.exp_dir = str(tmpdir)
     test_experiment_sim_cfg.paths.datasets_dir = str(tmpdir)


### PR DESCRIPTION
Closes #211

Tested exceptions by running unit test and deleting some of the required files
in second of three produced items. This caused an excepting which was caught by
inner exception handler and only two files were saved with appropriate summary.
